### PR TITLE
homebase-lite-app: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,50 @@
-# Tezos Homebase Lite Frontend
-[![](https://img.shields.io/badge/license-MIT-brightgreen)](LICENSE)
+# Homebase Lite App (Deprecated)
 
-Homebase lite is a platform designed to let users create and manage DAOs on the Tezos blockchain.
+## Overview
+
+This repository, `homebase-lite-app`, has been deprecated. All functionalities and future development have been moved to the main repository, [`homebase-app`](https://github.com/dOrgTech/homebase-app). This README serves as a guide for developers and users during this transition.
+
+## Deprecation Notice
+
+As part of our ongoing efforts to streamline our development process and consolidate our resources, `homebase-lite-app` is officially deprecated. We have integrated its features and capabilities into the main repository, `homebase-app`.
+
+For future development, contributions, and updates, please refer to: [`homebase-app`](https://github.com/dOrgTech/homebase-app).
+
+### Why Deprecate?
+
+The decision to deprecate `homebase-lite-app` was made to:
+
+- Enhance the overall functionality by consolidating features.
+- Provide a unified experience for our users and developers.
+- Simplify maintenance and support for our team.
+
+### Migration Guide
+
+If you are transitioning from `homebase-lite-app` to `homebase-app`, here's what you need to know:
+
+1. **Check Out the Main Repository:** Visit [`homebase-app`](https://github.com/dOrgTech/homebase-app) for the latest version and updates.
+2. **Migrating Your Work:** If you have ongoing work or contributions in `homebase-lite-app`, please migrate them to `homebase-app`. Instructions for migration are available in the `homebase-app` repository.
+
+## Archiving the Repository
+
+`Homebase-lite-app` is now in a read-only state. It will no longer receive updates or accept contributions. This is part of the archiving process on GitHub, marking the end of its active development and maintenance.
+
+### Before Archiving
+
+- All open issues and pull requests have been resolved or migrated to `homebase-app`.
+- All relevant features and information are transferred to the main repository.
+
+### Post-Archiving
+
+The repository will remain accessible for historical purposes, but it will not be updated. For active development and contributions, please use the [`homebase-app`](https://github.com/dOrgTech/homebase-app) repository.
+
+## Additional Information
+
+We appreciate the community's support and contributions to `homebase-lite-app`. As we move forward with `homebase-app`, we aim to provide a more integrated and efficient experience for all users and developers.
+
+For any questions or concerns regarding this transition, please reach out to the project maintainers.
+
+## References
+
+- Deprecated Repository: [`homebase-lite-app`](https://github.com/dOrgTech/homebase-lite-app)
+- Main Repository: [`homebase-app`](https://github.com/dOrgTech/homebase-app)


### PR DESCRIPTION
### Overview
This pull request updates the README of the `homebase-lite-app` repository to reflect its deprecation and transition to the `homebase-app` repository. The aim is to guide developers and users smoothly through this change and prepare the repository for its archival.

### Key Changes
**Deprecation Notice:**
- Added a prominent deprecation notice at the top of the README to immediately inform visitors about the repository's status.
- This notice directs users to the active `homebase-app` repository for ongoing development and updates.

**Migration Information:**
- Included a brief explanation of why `homebase-lite-app` is being deprecated and integrated into `homebase-app`.
- Provided a direct link to `homebase-app` for easy redirection of users and developers.

**Archiving Details:**
- Updated the README with information about the archiving process, emphasizing that the repository will no longer receive updates or contributions.
- Added guidance for users and developers on how to transition to `homebase-app`.

**Additional Guidance:**
- Included instructions for users and developers on migrating their work or contributions to `homebase-app`.

### Additional Notes
The changes made in this pull request are crucial for ensuring a clear understanding of the repository's status and the future direction of development. It is essential to guide the community effectively during this transition phase.

### Linked Issue
This pull request addresses the requirements and preparations outlined in the ZenHub issue: [Deprecation and Archiving of `homebase-lite-app`](https://app.zenhub.com/workspaces/tezos-homebase-63238426ddf385159a4c4b12/issues/gh/dorgtech/homebase-app/737).